### PR TITLE
Implement parallel model loading using furrr

### DIFF
--- a/R/readInGLMM.R
+++ b/R/readInGLMM.R
@@ -377,11 +377,16 @@ ReadModel_multiTrait = function(GMMATmodelFileList = "", chrom="", LOCO=TRUE, is
   # Check file existence
   GMMATmodelFileVec = unlist(strsplit(GMMATmodelFileList, split=","))
   modglmmList = list()
-  for(gm in 1:length(GMMATmodelFileVec)){
-     GMMATmodelFile = GMMATmodelFileVec[gm] 
-     modglmmList[[gm]] = ReadModel(GMMATmodelFile, chrom, LOCO, is_Firth_beta, is_EmpSPA, espa_nt, espa_range)  
+  if (require("furrr")) {
+    future::plan("multicore")
+    modglmmList = furrr::future_map(GMMATmodelFileVec, function(GMMATmodelFile){ReadModel(GMMATmodelFile, chrom, LOCO, is_Firth_beta, is_EmpSPA, espa_nt, espa_range)})
+    future::plan("sequential")
+  } else {
+    for(gm in 1:length(GMMATmodelFileVec)){
+      GMMATmodelFile = GMMATmodelFileVec[gm]
+      modglmmList[[gm]] = ReadModel(GMMATmodelFile, chrom, LOCO, is_Firth_beta, is_EmpSPA, espa_nt, espa_range)
+    }
   }
- 
   return(modglmmList)
 }
 

--- a/docker/install_packages.R
+++ b/docker/install_packages.R
@@ -7,7 +7,7 @@ install.packages("vctrs", repos='http://cran.rstudio.com/')
 print(packageVersion("vctrs"))
 
 
-req_packages <- c("R.utils", "devtools", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "roxygen2", "rversions","devtools", "SKAT", "RhpcBLASctl", "qlcMatrix", "dplyr", "dbplyr", "RcppNumerical")
+req_packages <- c("R.utils", "devtools", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "roxygen2", "rversions","devtools", "SKAT", "RhpcBLASctl", "dplyr", "dbplyr", "RcppNumerical", "furrr")
 for (pack in req_packages) {
     if(!require(pack, character.only = TRUE)) {
         install.packages(pack, repos = "https://cloud.r-project.org", dependencies=TRUE)
@@ -15,7 +15,7 @@ for (pack in req_packages) {
     }
 }
 
-github_packages <- c("leeshawn/MetaSKAT")
+github_packages <- c("leeshawn/MetaSKAT", "cysouw/qlcMatrix")
 for (pack in github_packages) {
     if(!require(pack, character.only = TRUE)) {
         devtools::install_github(pack)

--- a/extdata/install_packages.R
+++ b/extdata/install_packages.R
@@ -7,7 +7,7 @@ install.packages("vctrs", repos='http://cran.rstudio.com/')
 print(packageVersion("vctrs"))
 
 
-req_packages <- c("R.utils", "devtools", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "roxygen2", "rversions","devtools", "SKAT", "RhpcBLASctl", "dplyr", "dbplyr", "RcppNumerical")
+req_packages <- c("R.utils", "devtools", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "roxygen2", "rversions","devtools", "SKAT", "RhpcBLASctl", "dplyr", "dbplyr", "RcppNumerical", "furrr")
 for (pack in req_packages) {
     if(!require(pack, character.only = TRUE)) {
         install.packages(pack, repos = "https://cloud.r-project.org", dependencies=TRUE)


### PR DESCRIPTION
I modified `ReadModel_multiTrait` so that model files are loaded in parallel when `furrr` is installed and multiple cores are available.

@weizhou0 Is there any reason there are two `install_packages.R` under `extdata/` and `docker/`? They are almost same and `Dockerfile` can copy `extdata/install_packages.R`