### PR TITLE
Reduce step1 model file size

### DIFF
--- a/R/SAIGE_fitGLMM_fast_multiV.R
+++ b/R/SAIGE_fitGLMM_fast_multiV.R
@@ -1081,8 +1081,10 @@ file.remove(paste0(outputPrefix, "_", phenoCol, "_size_temp"))
 		W = W * modglmm$varWeights;
                 tauVecNew = modglmm$theta
                 Sigma_iX =  getSigma_X_multiV(W, tauVecNew, modglmm$X, maxiterPCG, tolPCG, LOCO=FALSE)
-                Sigma_iXXSigma_iX = Sigma_iX%*%(solve(t(modglmm$X)%*%Sigma_iX))
-                modglmm$Sigma_iXXSigma_iX = Sigma_iXXSigma_iX
+                if (!isShrinkModelOutput) {
+                  Sigma_iXXSigma_iX = Sigma_iX%*%(solve(t(modglmm$X)%*%Sigma_iX))
+                  modglmm$Sigma_iXXSigma_iX = Sigma_iXXSigma_iX
+                }
         #}
     
         modglmm$useSparseGRMforVarRatio = useSparseGRMforVarRatio 	   

--- a/R/SAIGE_fitGLMM_fast_multiV.R
+++ b/R/SAIGE_fitGLMM_fast_multiV.R
@@ -46,6 +46,7 @@
 #' @param sexCol character. Coloumn name for sex in the phenotype file, e.g Sex. By default, '' 
 #' @param isCovariateOffset logical. Whether to estimate fixed effect coeffciets. By default, FALSE.  
 #' @param isStoreSigma logical. Whether to store sigma matrix. By default, FALSE. If number of individuals is greater than 10,000, this option may use large memory
+#' @param isShrinkModelOutput logical. remove unnecessary objects for step2 from the model output. By default, FALSE.
 #' @return a file ended with .rda that contains the glmm model information, a file ended with .varianceRatio.txt that contains the variance ratio values, and a file ended with #markers.SPAOut.txt that contains the SPAGMMAT tests results for the markers used for estimating the variance ratio.
 #' @export
 fitNULLGLMM_multiV = function(plinkFile = "",
@@ -112,7 +113,8 @@ fitNULLGLMM_multiV = function(plinkFile = "",
 		VcellmatFilelist = "",
 		VcellmatSampleFilelist = "", 
 		useGRMtoFitNULL=TRUE, 
-		isStoreSigma = FALSE)
+		isStoreSigma = FALSE,
+		isShrinkModelOutput = FALSE)
 {
 
     ##set up output files
@@ -1328,6 +1330,26 @@ file.remove(paste0(outputPrefix, "_", phenoCol, "_size_temp"))
     }
     closeGenoFile_plink()
 
+    # clean up saved model (as in ReadModel)
+    if (isShrinkModelOutput) {
+      load(modelOut)
+      modglmm$Y = NULL
+      modglmm$linear.predictors = NULL
+      modglmm$coefficients = NULL
+      modglmm$cov = NULL
+      if (sum(duplicated(modglmm$sampleID)) > 0) {
+        modglmm$obj.noK$Sigma_iXXSigma_iX <- matrix(1)
+        modglmm$X <- NULL
+        if (is.null(modglmm$eMat)) {
+          modglmm$obj.noK$XV <- NULL
+          modglmm$obj.noK$XVX <- NULL
+          modglmm$obj.noK$XXVX_inv <- NULL
+          modglmm$obj.noK$XVX_inv <- NULL
+          modglmm$obj.noK$XVX_inv_XV <- NULL
+        }
+      }
+      save(modglmm, file = modelOut)
+    }
 }
 
 

--- a/extdata/step1_fitNULLGLMM_qtl.R
+++ b/extdata/step1_fitNULLGLMM_qtl.R
@@ -132,7 +132,9 @@ option_list <- list(
        make_option("--varWeightsCol", type="character", default=NULL,
    help="variance weight column"),
   make_option("--isStoreSigma", type="logical", default=TRUE,
-   help="Optional. Whether to store the inv Sigma matrix. [default, 'TRUE']")
+   help="Optional. Whether to store the inv Sigma matrix. [default, 'TRUE']"),
+  make_option("--isShrinkModelOutput", type="logical", default=TRUE,
+   help="Optional. Whether to remove unnecessary objects for step2 from the model output. [default, 'TRUE']")
 )
 
 
@@ -221,7 +223,8 @@ fitNULLGLMM_multiV(plinkFile=opt$plinkFile,
 	    offsetCol=opt$offsetCol,
 	    varWeightsCol=opt$varWeightsCol,
 	    sampleCovarCol=scovars,
-	    isStoreSigma=opt$isStoreSigma
+	    isStoreSigma=opt$isStoreSigma,
+      isShrinkModelOutput=opt$isShrinkModelOutput
 	)
 
 if(!opt$isCovariateOffset){
@@ -292,7 +295,8 @@ if(!opt$isCovariateOffset){
             offsetCol=opt$offsetCol,
             varWeightsCol=opt$varWeightsCol,
             sampleCovarCol=scovars,
-            isStoreSigma=opt$isStoreSigma
+            isStoreSigma=opt$isStoreSigma,
+            isShrinkModelOutput=opt$isShrinkModelOutput
         )
        my_env = new.env()
        load(paste0(opt$outputPrefix, ".offset.rda"), envir = my_env)


### PR DESCRIPTION
I added a new option `--isShrinkModelOutput` (default: TRUE) to reduce step1 model file size. Unnecessary objects in `modglmm` (which becomes `NULL` in `ReadModel` to save memory) are removed before save.

This option reduces `.rda` file size by 50-60% when eCovars are not included