### PR TITLE
use crossprod when applicable and implement fastSave in step1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,10 +7,11 @@ Author: Wei Zhou, Anna Cuomo
 Maintainer: Wei Zhou <wzhou@broadinstitute.org> 
 Description:an R package that implements the Scalable and Accurate Implementation of Generalized Poisson mixed model for eQTL mapping at the single-cell level.  
 License: GPL (>= 2)
-Imports: Rcpp (>= 1.0.7), RcppParallel, Matrix, data.table, RcppArmadillo (>= 0.10.7.5), RcppNumerical
+Imports: Rcpp (>= 1.0.7), RcppParallel, Matrix, data.table, RcppArmadillo (>= 0.10.7.5), RcppNumerical, furrr, fastSave, dbplyr
+Suggests: R.utils
 LinkingTo: Rcpp, RcppArmadillo (>= 0.10.7.5), RcppParallel, data.table, SPAtest (== 3.1.2),
         RcppEigen, Matrix, methods, BH, optparse, SKAT, MetaSKAT, qlcMatrix, RhpcBLASctl, RSQLite, dplyr, nlme, MASS, RcppEigen, RcppNumerical
-Remotes: cysouw/qlcMatrix, leeshawn/MetaSKAT
+Remotes: cysouw/qlcMatrix, leeshawn/MetaSKAT, barkasn/fastSave
 Depends: R (>= 3.5.0)
 SystemRequirements: GNU make
 RoxygenNote: 7.1.2

--- a/R/Util.R
+++ b/R/Util.R
@@ -639,3 +639,14 @@ writeOutputFileIndex <- function(OutputFileIndex,
     write.table(message5, OutputFileIndex, quote = F, sep = "\t", append = T, col.names = F, row.names = F)
   }
 }
+
+fastSave <- function(modglmm, file, n.cores = NULL) {
+  if (require(fastSave) & system("command -v pigz", wait = T, ignore.stdout = TRUE, ignore.stderr = TRUE) == 0) {
+    if (is.null(n.cores)) {
+      n.cores <- parallel::detectCores()
+    }
+    fastSave::save.pigz(modglmm, file = file, n.cores = n.cores)
+  } else {
+    save(modglmm, file = file)
+  }
+}


### PR DESCRIPTION
This PR applies the following:
* use `crossprod(X, Y)` to replace `t(X) %*% Y`. This reduces the step 1 computation time by 30-50% depending on data sets.
* use `fastSave::save.pigz` for faster save if `pigz` is available. The output `.rda` is compatible with standard `save`
* Minor: fix a bug when `isphenoFileLarge`