### PR TITLE
Ensure sample alignment when skipping variance ratio

### DIFF
--- a/R/SAIGE_fitGLMM_fast_multiV.R
+++ b/R/SAIGE_fitGLMM_fast_multiV.R
@@ -291,6 +291,24 @@ fitNULLGLMM_multiV <- function(plinkFile = "",
       cat(nrow(sampleListwithGeno), " samples are in the sparse GRM\n")
     }
   }
+  if (is.null(sampleListwithGeno) && plinkFile != "") {
+    if (!file.exists(famFile)) {
+      stop("ERROR! fam file does not exsit\n")
+    } else {
+      sampleListwithGenov0 <- data.table::fread(famFile, header = F, colClasses = list(character = 1:4), data.table = FALSE)
+      colnames(sampleListwithGenov0) <- c(
+        "FIDgeno", "IIDgeno",
+        "father", "mother", "sex", "phe"
+      )
+      sampleListwithGeno <- NULL
+      sampleListwithGeno$IIDgeno <- sampleListwithGenov0$IIDgeno
+      sampleListwithGeno <- data.frame(sampleListwithGeno)
+      sampleListwithGeno$IndexGeno <- seq(1, nrow(sampleListwithGeno),
+        by = 1
+      )
+      cat(nrow(sampleListwithGeno), " genotype samples will be used to align phenotypes even though variance ratio estimation is skipped\n")
+    }
+  }
   if (!file.exists(phenoFile)) {
     stop("ERROR! phenoFile ", phenoFile, " does not exsit\n")
   } else {


### PR DESCRIPTION
 - Fixed bugs when `--skipVarianceRatioEstimation=TRUE` activated
 - Always load PLINK FAM whenever a plinkFile is present so Step1 still intersects/aligns samples with genotypes even if variance-ratio estimation is skipped.
 - Prevents Step1 from pulling in phenotype-only rows when `--skipVarianceRatioEstimation=TRUE`, matching behavior with the variance-ratio path.